### PR TITLE
Upgrade grunt-contrib-cssmin to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "grunt-contrib-compass": "~0.6.0",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-copy": "~0.4.1",
-    "grunt-contrib-cssmin": "~0.7.0",
+    "grunt-contrib-cssmin": "~0.8.0",
     "grunt-contrib-htmlmin": "~0.1.3",
     "jpegtran-bin": "0.2.0",
     "grunt-contrib-imagemin": "~0.3.0",


### PR DESCRIPTION
The current version of `grunt-contrib-cssmin` or some of its dependencies is now crippling the font `@import` in minified CSS, which then end up in not loading fonts properly:

![screen shot 2014-02-28 at 20 40 06](https://f.cloud.github.com/assets/287584/2298173/8ab31dfc-a0b8-11e3-810e-9b95caecb3d9.png)

It can be fixed just by upgrading the version:

![screen shot 2014-02-28 at 20 40 47](https://f.cloud.github.com/assets/287584/2298178/a1a8ca66-a0b8-11e3-96fa-4e674da4920f.png)
