### PR TITLE
Fix dependency issue with superagent-retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cacher-redis": "*",
     "phantomjs": "*",
     "node-phantom": "*",
-    "superagent-retry": "*"
+    "superagent-retry": "~0.1.1"
   },
   "devDependencies": {
     "grunt": "~0.4.2",


### PR DESCRIPTION
superagent-retry version was bumped to 0.2.0 since creation of hub.
Commit locks version to 0.1.1.

"*" causes the following npm error:
**npm ERR! peerinvalid The package superagent does not satisfy its siblings' peerDependencies requirements!**

**npm ERR! peerinvalid Peer superagent-retry@0.2.0 wants superagent@~0.16.0**
