### PR TITLE
Merge develop into master for v0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 GDG[x] Hub
 ===
 
+[![Join the chat at https://gitter.im/gdg-x/hub](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/gdg-x/hub?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 [![Build Status](https://travis-ci.org/gdg-x/hub.png?branch=master)](https://travis-ci.org/gdg-x/hub)
 
 The public instance of the GDG[x] Hub is hosted at [https://hub.gdgx.io]

--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ grunt serve
 grunt build
 ```
 The distributable version will be placed in /dist
+
+## History (just for the fun of it)
+
+https://docs.google.com/document/d/1X8fuwTvA4Y2Hm_PmP8gE_VH6kNd6lYGXjbOfoNUapcM/edit?usp=sharing&authkey=CMiRgOYF

--- a/app/views/partials/event.html
+++ b/app/views/partials/event.html
@@ -55,6 +55,17 @@
 					</div>
 				</div>
 			</div>
+	                <div class="row">
+				<div class="span3">
+					<h3>Event Site</h3>
+					<div class="card">
+						<div class="card-wh-body">
+						<img ng-show="event.eventUrl != undefined" class="pull-right" style="margin-top: 11px;" ng-src="{{image}}"/>
+							<h3><a ng-href="{{event.eventUrl}}">Google+ event page</a></h3>
+						</div>
+					</div>
+				</div>
+			</div>			
 			<div class="row">
 				<div class="card span3">
 					<div class="card-wh-body">


### PR DESCRIPTION
Opening this so that we can sync up master and develop before the GDG Taskforce work begins.

Adds
- Gitter badge
- History doc link
- Card to event page with G+ event link
