### PR TITLE
Fix calendar event loading to work with new version of fullcalendar.js.

### DIFF
--- a/app/scripts/controllers/event.js
+++ b/app/scripts/controllers/event.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('gdgxHubApp')
-  .controller('EventCtrl', function ($scope, $http, $routeParams, $location) {
+  .controller('EventCtrl', function ($scope, $http, $routeParams, $location, uiCalendarConfig) {
 
     $scope.alertOnEventClick = function (event) {
       $location.path('/events/' + event.id);
@@ -40,7 +40,7 @@ angular.module('gdgxHubApp')
     };
 
     $scope.changeCalendarView = function (view, calendar) {
-      calendar.fullCalendar('changeView', view);
+      uiCalendarConfig.calendars[calendar].fullCalendar('changeView', view);
     };
 
     $scope.eventSource = [$scope.events];

--- a/app/scripts/controllers/event.js
+++ b/app/scripts/controllers/event.js
@@ -4,9 +4,7 @@ angular.module('gdgxHubApp')
   .controller('EventCtrl', function ($scope, $http, $routeParams, $location) {
 
     $scope.alertOnEventClick = function (event) {
-      $scope.$apply(function () {
-        $location.path('/events/' + event.id);
-      });
+      $location.path('/events/' + event.id);
     };
 
     $scope.allCalendarConfig = {

--- a/app/scripts/controllers/event.js
+++ b/app/scripts/controllers/event.js
@@ -18,8 +18,8 @@ angular.module('gdgxHubApp')
       eventClick: $scope.alertOnEventClick
     };
 
-    $scope.events = function (start, end, callback) {
-      $http.get('/api/v1/events/' + start.unix() + '/' + end.unix() +
+    $scope.events = function (start, end, timezone, callback) {
+      $http.get('/api/v1/events/' + start.toDate().getTime() + '/' + end.toDate().getTime() +
       '?perpage=1000&fields=title,chapter,start,end,allDay')
         .success(function (resp) {
           var events = [];

--- a/app/views/partials/events.html
+++ b/app/views/partials/events.html
@@ -10,8 +10,8 @@
 				<button class="btn btn-success" ng-click="changeCalendarView('agendaDay', allCalendar)">Day</button>
 	            <button class="btn btn-success" ng-click="changeCalendarView('agendaWeek', allCalendar)">Week</button>
 	            <button class="btn btn-success" ng-click="changeCalendarView('month', allCalendar)">Month</button>
-            </div>
-			<div ui-calendar="allCalendarConfig" config="allCalendarConfig" ng-model="eventSource" calendar="allCalendar"></div>
+      </div>
+			<div ui-calendar="allCalendarConfig" ng-model="eventSource" calendar="allCalendar"></div>
 		</div>
 	</div>
 </div>

--- a/app/views/partials/events.html
+++ b/app/views/partials/events.html
@@ -7,9 +7,9 @@
 	<div class="row">
 		<div class="span12">
 			<div class="btn-group">
-				<button class="btn btn-success" ng-click="changeCalendarView('agendaDay', allCalendar)">Day</button>
-	            <button class="btn btn-success" ng-click="changeCalendarView('agendaWeek', allCalendar)">Week</button>
-	            <button class="btn btn-success" ng-click="changeCalendarView('month', allCalendar)">Month</button>
+				<button class="btn btn-success" ng-click="changeCalendarView('agendaDay', 'allCalendar')">Day</button>
+	            <button class="btn btn-success" ng-click="changeCalendarView('agendaWeek', 'allCalendar')">Week</button>
+	            <button class="btn btn-success" ng-click="changeCalendarView('month', 'allCalendar')">Month</button>
       </div>
 			<div ui-calendar="allCalendarConfig" ng-model="eventSource" calendar="allCalendar"></div>
 		</div>


### PR DESCRIPTION
fullcalendar.js changed their API to add a timezone argument and to pass Moment.js dates instead of JavaScript Dates. This broke the existing events page of the Hub. These changes update the event page to work with the new API. fullcalendar.js is pulled in via the ui-calender from Angular-UI.
