### PR TITLE
update(tests): Fix warnings w/ karma & update karma-phantomjs-launcher

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,4 @@
+'use strict';
 // Karma configuration
 // http://karma-runner.github.io/0.10/config/configuration-file.html
 
@@ -22,7 +23,6 @@ module.exports = function(config) {
       'app/bower_components/angular-directive.g-signin/google-plus-signin.js',
       'app/bower_components/underscore/underscore.js',
       'app/bower_components/angular-google-maps/dist/angular-google-maps.js',
-      'app/bower_components/jquery-ui/ui/jquery-ui.js',
       'app/bower_components/angular-bootstrap/ui-bootstrap-tpls.js',
       'app/bower_components/moment/moment.js',
       'app/bower_components/fullcalendar/dist/fullcalendar.js',

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "karma-jasmine": "0.1.5",
     "karma-ng-html2js-preprocessor": "0.1.0",
     "karma-ng-scenario": "0.1.0",
-    "karma-phantomjs-launcher": "0.1.1",
+    "karma-phantomjs-launcher": "0.2.1",
     "karma-requirejs": "0.2.1",
     "karma-script-launcher": "0.1.0",
     "load-grunt-tasks": "0.2.0",


### PR DESCRIPTION
Add `use strict` statement to karma.conf.js.
Remove jquery-ui.js since it is no longer used and was causing a warning.
