### PR TITLE
Fix perpage parsing

### DIFF
--- a/lib/controllers/api/utils.js
+++ b/lib/controllers/api/utils.js
@@ -13,7 +13,7 @@ module.exports = {
 
 		asc = parseInt(asc);
 
-		if(limit === undefined) {
+		if (limit === undefined) {
       limit = 30;
     }
 
@@ -26,19 +26,19 @@ module.exports = {
 		delete options.page;
 		delete options.perpage;
 
-		/*for(var key in options) {
+		/*for (var key in options) {
 			query.where(key);
 
 			var value = options[key];
-			if('>' == value[0]) {
-				if('=' == value[1]) {
+			if ('>' == value[0]) {
+				if ('=' == value[1]) {
 					query.gte(value.substr(2));
 				} else {
 					query.gt(value.substr(1));
 				}
 			}
-			else if('<' == value[0]) {
-				if('=' == value[1]) {
+			else if ('<' == value[0]) {
+				if ('=' == value[1]) {
 					query.lte(value.substr(2));
 				} else {
 					query.lt(value.substr(1));
@@ -48,13 +48,13 @@ module.exports = {
 			}
 		}*/
 
-		if(count === undefined) {
-			if(sort) {
+		if (count === undefined) {
+			if (sort) {
 				var so = {};
 				so[sort] = asc;
-				query.options["sort"] = so;
+				query.options.sort = so;
 			}
-			if(fields) {
+			if (fields) {
 				query.select(fields.split(/[ ,]+/).join(' '));
 			}
 		}
@@ -68,10 +68,10 @@ module.exports = {
 		resultsPerPage = resultsPerPage || 25;
 		var skipFrom = (page * resultsPerPage) - resultsPerPage;
 
-		if(resultsPerPage !== -1) {
+		if (resultsPerPage !== -1) {
 			q.limit(resultsPerPage);
 		} else {
-			delete q["options"]["limit"];
+			delete q.options.limit;
 		}
 
 		var query = q.skip(skipFrom);
@@ -96,51 +96,47 @@ module.exports = {
 	},
 
 	parseAndOr: function(query, key, value, it) {
+    var elements, o, i;
 
-		if(!value || typeof value === 'object')
-			return;
+		if (!value || typeof value === 'object') {
+      return;
+    }
 
-		if(value.indexOf(",") !== -1) {
-			var elements = value.split(',');
-			query["$or"] = [];
+		if (value.indexOf(",") !== -1) {
+			elements = value.split(',');
+			query.$or = [];
 
 			delete query[key];
 
-			for(var i = 0; i < elements.length; i++) {
-				var o = {};
-
-				query["$or"].push(this.parseAndOr(query, key, elements[i], true));
+			for (i = 0; i < elements.length; i++) {
+				o = {};
+				query.$or.push(this.parseAndOr(query, key, elements[i], true));
 			}
-		} else if(value.indexOf("+") !== -1) {
-			var elements = value.split('+');
+		} else if (value.indexOf("+") !== -1) {
+			elements = value.split('+');
 
-			var target;
-
-			if(it) {
-				var o = {};
-				o["$and"] = [];
-				for(var i = 0; i < elements.length; i++) {
+			if (it) {
+				o = {};
+        o.$and = [];
+				for (i = 0; i < elements.length; i++) {
 					var or = {};
 					or[key] = elements[i];
-					o["$and"].push(or);
+          o.$and.push(or);
 				}
 				return o;
 			} else {
 				delete query[key];
 
-				query["$and"] = [];
-				for(var i = 0; i < elements.length; i++) {
-					var o = {};
+				query.$and = [];
+				for (i = 0; i < elements.length; i++) {
+					o = {};
 					o[key] = elements[i];
-
-					query["$and"].push(o);
+					query.$and.push(o);
 				}
 			}
-
 		} else {
-
-			if(it) {
-				var o = {};
+			if (it) {
+				o = {};
 				o[key] = value;
 				return o;
 			} else {
@@ -160,28 +156,28 @@ module.exports = {
 
 			var query = extend({}, baseQuery);
 
-			for(var key in query) {
+			for (var key in query) {
 				me.parseAndOr(query, key, req.params[query[key]]);
 			}
 
 			var targetQuery;
 			var count = false;
 
-			if(req.query.count !== undefined) {
+			if (req.query.count !== undefined) {
 				count = true;
 				targetQuery = Model.count(query);
 			} else {
 
-				if(one) {
+				if (one) {
 					targetQuery = Model.findOne(query, null, options);
 				} else {
 					targetQuery = Model.find(query, null, options);
 				}
 
-				for(var i = 0; i < populate.length; i++) {
+				for (var i = 0; i < populate.length; i++) {
 					var item = populate[i];
 
-					if(item instanceof Array) {
+					if (item instanceof Array) {
 						targetQuery = targetQuery.populate(item[0], item[1]);
 					} else {
 						targetQuery = targetQuery.populate(item);
@@ -189,22 +185,22 @@ module.exports = {
 				}
 			}
 
-			if(count) {
+			if (count) {
 				me.buildQuery(targetQuery, req.query).exec(function(err, count) {
-					if(err) {
+					if (err) {
 						console.log(err);
 						res.send(400, 'Bad request');
 					} else {
 						res.jsonp({ count: count });
 					}
 				});
-			} else if(one) {
+			} else if (one) {
 				me.buildQuery(targetQuery, req.query).exec(function(err, item) {
-					if(err) {
+					if (err) {
 						console.log(err);
 						res.send(400, 'Bad request');
 					} else {
-						if(!item)
+						if (!item)
 							res.send(404, "Not found");
 						else
 							res.jsonp(item);
@@ -214,12 +210,14 @@ module.exports = {
 				var page = parseInt(req.query.page);
 				var perpage = req.query.perpage ? parseInt(req.query.perpage) : undefined;
 
-				if(perpage && perpage < -1) {
+				if (perpage && perpage < -1) {
 					res.send(400, 'Bad request');
 				}
 
-				me.paginate(me.buildQuery(targetQuery, req.query), page, perpage, function(err, count, page, resultsPerPage, pageCount, results) {
-					if(err) {
+				me.paginate(me.buildQuery(targetQuery, req.query), page, perpage,
+          function(err, count, page, resultsPerPage, pageCount, results) {
+
+					if (err) {
 						console.log(err);
 						res.send(400, 'Bad request');
 					} else {
@@ -228,14 +226,13 @@ module.exports = {
 						};
 
 						console.log("resultsPerPage :" + resultsPerPage);
-						if(resultsPerPage !== -1) {
-							response["pages"] = pageCount;
-							response["page"] = page;
-							response["perPage"] = resultsPerPage;
+						if (resultsPerPage !== -1) {
+							response.pages = pageCount;
+							response.page = page;
+							response.perpage = resultsPerPage;
 						}
 
-						response["items"] = results;
-
+						response.items = results;
 						res.jsonp(response);
 					}
 				});
@@ -254,11 +251,11 @@ module.exports = {
 
 				var cachedHeaders = {};
 				for (var header in res._headers) {
-					if(res._headerNames[header].indexOf("X-") === -1 && res._headerNames[header] !== "Set-Cookie")
+					if (res._headerNames[header].indexOf("X-") === -1 && res._headerNames[header] !== "Set-Cookie")
 	    				cachedHeaders[res._headerNames[header]] = res._headers[header];
 	  			}
 
-	  			if(res.statusCode === 200) {
+	  			if (res.statusCode === 200) {
 					var cacheObject = {statusCode: res.statusCode, content: res._responseBody, headers: cachedHeaders};
 
 					self.client.set(key, cacheObject, realTtl, function(err) {

--- a/lib/controllers/api/utils.js
+++ b/lib/controllers/api/utils.js
@@ -1,344 +1,343 @@
 'use strict';
 
 var mongoose = require('mongoose'),
-	  extend = require('util')._extend;
+  extend = require('util')._extend;
 
 module.exports = {
-	buildQuery: function(query, options) {
-		var skip = options.skip;
-		var limit = options.limit;
-		var sort = options.sort;
-		var asc = options.asc || 1;
-		var fields = options.fields;
+  /**
+   * @param {object} query
+   * @param {object} options
+   * @param {string} options.sort
+   * @param {integer} options.asc
+   * @param {integer} options.page
+   * @param {integer} options.perpage
+   * @returns {object} query with options applied
+   */
+  buildQuery: function (query, options) {
+    var sort = options.sort;
+    var asc = parseInt(options.asc || '1', 10);
+    var fields = options.fields;
+    var count = options.count;
 
-		asc = parseInt(asc);
+    delete options.sort;
+    delete options.asc;
+    delete options.fields;
+    delete options.count;
+    delete options.page;
+    delete options.perpage;
 
-		if (limit === undefined) {
-      limit = 30;
+    if (!count) {
+      if (sort) {
+        var sortOptions = {};
+        sortOptions[sort] = asc;
+        query.options.sort = sortOptions;
+      }
+      if (fields) {
+        query.select(fields.split(/[ ,]+/).join(' '));
+      }
     }
 
-		var count = options.count;
+    return query;
+  },
 
-		delete options.sort;
-		delete options.asc;
-		delete options.fields;
-		delete options.count;
-		delete options.page;
-		delete options.perpage;
+  /**
+   * @param {object} query
+   * @param {integer} pageNumber
+   * @param {integer} resultsPerPage
+   * @param {Function} callback
+   */
+  paginate: function (query, pageNumber, resultsPerPage, callback) {
+    callback = callback || function () {};
+    pageNumber = (!isNaN(pageNumber) && pageNumber !== undefined) ? parseInt(pageNumber) : 1;
+    resultsPerPage = resultsPerPage || 25;
+    var skipFrom = (pageNumber * resultsPerPage) - resultsPerPage;
 
-		/*for (var key in options) {
-			query.where(key);
+    if (resultsPerPage !== -1) {
+      query.limit(resultsPerPage);
+    } else {
+      delete query.options.limit;
+    }
 
-			var value = options[key];
-			if ('>' == value[0]) {
-				if ('=' == value[1]) {
-					query.gte(value.substr(2));
-				} else {
-					query.gt(value.substr(1));
-				}
-			}
-			else if ('<' == value[0]) {
-				if ('=' == value[1]) {
-					query.lte(value.substr(2));
-				} else {
-					query.lt(value.substr(1));
-				}
-			} else {
-				query.equals(value);
-			}
-		}*/
+    var queryStep = query.skip(skipFrom);
 
-		if (count === undefined) {
-			if (sort) {
-				var so = {};
-				so[sort] = asc;
-				query.options.sort = so;
-			}
-			if (fields) {
-				query.select(fields.split(/[ ,]+/).join(' '));
-			}
-		}
+    queryStep.exec(function (error, results) {
+      if (error) {
+        callback(error, null, null, null, null, null);
+      } else {
+        query.model.count(query, function (error, count) {
+          if (error) {
+            callback(error, null, null);
+          } else {
+            var pageCount = Math.ceil(count / resultsPerPage);
+            if (pageCount === 0) {
+              pageCount = 1;
+            }
+            callback(null, count, pageNumber, resultsPerPage, pageCount, results);
+          }
+        });
+      }
+    });
+  },
 
-		return query;
-	},
-
-	paginate: function(q, page, resultsPerPage, callback) {
-		callback = callback || function(){};
-		page = (!isNaN(page) && page !== undefined) ? parseInt(page) : 1;
-		resultsPerPage = resultsPerPage || 25;
-		var skipFrom = (page * resultsPerPage) - resultsPerPage;
-
-		if (resultsPerPage !== -1) {
-			q.limit(resultsPerPage);
-		} else {
-			delete q.options.limit;
-		}
-
-		var query = q.skip(skipFrom);
-
-		query.exec(function(error, results) {
-		    if (error) {
-		      callback(error, null, null, null, null, null);
-		    } else {
-		      q.model.count(q, function(error, count) {
-		        if (error) {
-		          callback(error, null, null);
-		        } else {
-		          var pageCount = Math.ceil(count / resultsPerPage);
-		          if (pageCount === 0) {
-		            pageCount = 1;
-		          }
-		          callback(null, count, page, resultsPerPage, pageCount, results);
-		        }
-		      });
-		    }
-		});
-	},
-
-	parseAndOr: function(query, key, value, it) {
+  /**
+   * @param {object} query
+   * @param {string} key
+   * @param {string} value
+   * @param {boolean} it
+   * @returns {{}|*}
+   */
+  parseAndOr: function (query, key, value, it) {
     var elements, o, i;
 
-		if (!value || typeof value === 'object') {
-      return;
+    if (!value || typeof value === 'object') {
+      return null;
     }
 
-		if (value.indexOf(",") !== -1) {
-			elements = value.split(',');
-			query.$or = [];
+    if (value.indexOf(",") !== -1) {
+      elements = value.split(',');
+      query.$or = [];
 
-			delete query[key];
+      delete query[key];
 
-			for (i = 0; i < elements.length; i++) {
-				o = {};
-				query.$or.push(this.parseAndOr(query, key, elements[i], true));
-			}
-		} else if (value.indexOf("+") !== -1) {
-			elements = value.split('+');
+      for (i = 0; i < elements.length; i++) {
+        o = {};
+        query.$or.push(this.parseAndOr(query, key, elements[i], true));
+      }
+    } else if (value.indexOf("+") !== -1) {
+      elements = value.split('+');
 
-			if (it) {
-				o = {};
+      if (it) {
+        o = {};
         o.$and = [];
-				for (i = 0; i < elements.length; i++) {
-					var or = {};
-					or[key] = elements[i];
+        for (i = 0; i < elements.length; i++) {
+          var or = {};
+          or[key] = elements[i];
           o.$and.push(or);
-				}
-				return o;
-			} else {
-				delete query[key];
+        }
+        return o;
+      } else {
+        delete query[key];
 
-				query.$and = [];
-				for (i = 0; i < elements.length; i++) {
-					o = {};
-					o[key] = elements[i];
-					query.$and.push(o);
-				}
-			}
-		} else {
-			if (it) {
-				o = {};
-				o[key] = value;
-				return o;
-			} else {
-				query[key] = value;
-			}
-		}
-	},
+        query.$and = [];
+        for (i = 0; i < elements.length; i++) {
+          o = {};
+          o[key] = elements[i];
+          query.$and.push(o);
+        }
+      }
+    } else {
+      if (it) {
+        o = {};
+        o[key] = value;
+        return o;
+      } else {
+        query[key] = value;
+      }
+    }
+  },
 
-	getModel: function(model, baseQuery, populate, one, options) {
-		var me = this;
-		one = one !== undefined ? one : false;
-		populate = populate || [];
-		options = options || {};
+  /**
+   * @param {string} model name
+   * @param {object} baseQuery
+   * @param {array} populate
+   * @param {boolean} one
+   * @param {object} options
+   * @returns {Function}
+   */
+  getModel: function (model, baseQuery, populate, one, options) {
+    var me = this;
+    one = one || false;
+    populate = populate || [];
+    options = options || {};
 
-		return function(req, res) {
-			var Model = mongoose.model(model);
+    return function (req, res) {
+      var targetQuery, i;
+      var count = false;
+      var Model = mongoose.model(model);
+      var query = extend({}, baseQuery);
 
-			var query = extend({}, baseQuery);
+      for (var key in query) {
+        me.parseAndOr(query, key, req.params[query[key]]);
+      }
 
-			for (var key in query) {
-				me.parseAndOr(query, key, req.params[query[key]]);
-			}
+      if (req.query.count) {
+        count = true;
+        targetQuery = Model.count(query);
+      } else {
+        if (one) {
+          targetQuery = Model.findOne(query, null, options);
+        } else {
+          targetQuery = Model.find(query, null, options);
+        }
 
-			var targetQuery;
-			var count = false;
+        for (i = 0; i < populate.length; i++) {
+          var entity = populate[i];
 
-			if (req.query.count !== undefined) {
-				count = true;
-				targetQuery = Model.count(query);
-			} else {
+          if (entity instanceof Array) {
+            targetQuery = targetQuery.populate(entity[0], entity[1]);
+          } else {
+            targetQuery = targetQuery.populate(entity);
+          }
+        }
+      }
 
-				if (one) {
-					targetQuery = Model.findOne(query, null, options);
-				} else {
-					targetQuery = Model.find(query, null, options);
-				}
+      if (count) {
+        me.buildQuery(targetQuery, req.query).exec(function (err, count) {
+          if (err) {
+            console.log(err);
+            res.send(400, 'Bad request');
+          } else {
+            res.jsonp({count: count});
+          }
+        });
+      } else if (one) {
+        me.buildQuery(targetQuery, req.query).exec(function (err, item) {
+          if (err) {
+            console.log(err);
+            res.send(400, 'Bad request');
+          } else if (item) {
+            res.jsonp(item);
+          } else {
+            res.send(404, "Not found");
+          }
+        });
+      } else {
+        var page = parseInt(req.query.page);
+        var perpage = req.query.perpage ? parseInt(req.query.perpage) : undefined;
 
-				for (var i = 0; i < populate.length; i++) {
-					var item = populate[i];
+        if (perpage && perpage < -1) {
+          res.send(400, 'Bad request');
+        }
 
-					if (item instanceof Array) {
-						targetQuery = targetQuery.populate(item[0], item[1]);
-					} else {
-						targetQuery = targetQuery.populate(item);
-					}
-				}
-			}
+        me.paginate(me.buildQuery(targetQuery, req.query), page, perpage,
+          function (err, count, pageNumber, resultsPerPage, pageCount, results) {
 
-			if (count) {
-				me.buildQuery(targetQuery, req.query).exec(function(err, count) {
-					if (err) {
-						console.log(err);
-						res.send(400, 'Bad request');
-					} else {
-						res.jsonp({ count: count });
-					}
-				});
-			} else if (one) {
-				me.buildQuery(targetQuery, req.query).exec(function(err, item) {
-					if (err) {
-						console.log(err);
-						res.send(400, 'Bad request');
-					} else {
-						if (!item)
-							res.send(404, "Not found");
-						else
-							res.jsonp(item);
-					}
-				});
-			} else {
-				var page = parseInt(req.query.page);
-				var perpage = req.query.perpage ? parseInt(req.query.perpage) : undefined;
+            if (err) {
+              console.log(err);
+              res.send(400, 'Bad request');
+            } else {
+              var response = {
+                "count": count
+              };
 
-				if (perpage && perpage < -1) {
-					res.send(400, 'Bad request');
-				}
+              console.log("resultsPerPage :" + resultsPerPage);
+              if (resultsPerPage !== -1) {
+                response.pages = pageCount;
+                response.page = pageNumber;
+                response.perpage = resultsPerPage;
+              }
 
-				me.paginate(me.buildQuery(targetQuery, req.query), page, perpage,
-          function(err, count, page, resultsPerPage, pageCount, results) {
+              response.items = results;
+              res.jsonp(response);
+            }
+          }
+        );
+      }
+    };
+  },
 
-					if (err) {
-						console.log(err);
-						res.send(400, 'Bad request');
-					} else {
-						var response = {
-							"count": count
-						};
+  /**
+   * @param Cacher
+   */
+  fixCacher: function (Cacher) {
+    Cacher.prototype.buildEnd = function (res, key, staleKey, realTtl, ttl) {
+      var STALE_CREATED = 1;
+      var origEnd = res.end;
+      var self = this;
 
-						console.log("resultsPerPage :" + resultsPerPage);
-						if (resultsPerPage !== -1) {
-							response.pages = pageCount;
-							response.page = page;
-							response.perpage = resultsPerPage;
-						}
+      res.end = function (data) {
+        var cachedHeaders = {};
+        res._responseBody += data;
 
-						response.items = results;
-						res.jsonp(response);
-					}
-				});
-			}
-		};
-	},
+        for (var header in res._headers) {
+          if (res._headerNames[header].indexOf("X-") === -1 && res._headerNames[header] !== "Set-Cookie") {
+            cachedHeaders[res._headerNames[header]] = res._headers[header];
+          }
+        }
 
-	fixCacher: function(Cacher) {
-		Cacher.prototype.buildEnd = function(res, key, staleKey, realTtl, ttl) {
-			var STALE_CREATED = 1;
-			var origEnd = res.end;
-			var self = this;
+        if (res.statusCode === 200) {
+          var cacheObject = {statusCode: res.statusCode, content: res._responseBody, headers: cachedHeaders};
 
-			res.end = function (data) {
-				res._responseBody += data;
+          self.client.set(key, cacheObject, realTtl, function (err) {
+            if (err) {
+              self.emit("error", err);
+            }
+            self.client.set(staleKey, STALE_CREATED, ttl, function (err) {
+              if (err) {
+                self.emit("error", err);
+              }
+              self.emit("cache", cacheObject);
+            });
+          });
+        }
+        return origEnd.apply(res, arguments);
+      };
+    };
 
-				var cachedHeaders = {};
-				for (var header in res._headers) {
-					if (res._headerNames[header].indexOf("X-") === -1 && res._headerNames[header] !== "Set-Cookie")
-	    				cachedHeaders[res._headerNames[header]] = res._headers[header];
-	  			}
+    Cacher.prototype.cache = function (unit, value) {
+      var self = this;
+      var STALE_REFRESH = 2;
+      var GEN_TIME = 30;
 
-	  			if (res.statusCode === 200) {
-					var cacheObject = {statusCode: res.statusCode, content: res._responseBody, headers: cachedHeaders};
+      var HEADER_KEY = 'Cache-Control';
+      var NO_CACHE_KEY = 'no-cache';
+      var MAX_AGE_KEY = 'max-age';
+      var MUST_REVALIDATE_KEY = 'must-revalidate';
+      // set noCaching to true in dev mode to get around stale data when you don't want it
+      var ttl = self.calcTtl(unit, value);
+      if (ttl === 0 || this.noCaching) {
+        return function (req, res, next) {
+          res.header(HEADER_KEY, NO_CACHE_KEY);
+          next();
+        };
+      }
 
-					self.client.set(key, cacheObject, realTtl, function(err) {
-						if (err) {
-							self.emit("error", err);
-						}
-						self.client.set(staleKey, STALE_CREATED, ttl, function(err) {
-							if (err) {
-								self.emit("error", err);
-							}
-							self.emit("cache", cacheObject);
-						});
-					});
-				}
-				return origEnd.apply(res, arguments);
-			};
-		};
+      return function (req, res, next) {
+        // only cache on get and head
+        if (req.method !== 'GET' && req.method !== 'HEAD') {
+          return next();
+        }
 
-		Cacher.prototype.cache = function(unit, value) {
-			var self = this;
-			var STALE_REFRESH = 2;
-			var GEN_TIME = 30;
+        var key = self.genCacheKey(req);
+        var staleKey = key + ".stale";
+        var realTtl = ttl + GEN_TIME * 2;
 
-			var HEADER_KEY = 'Cache-Control';
-			var NO_CACHE_KEY = 'no-cache';
-			var MAX_AGE_KEY = 'max-age';
-			var MUST_REVALIDATE_KEY = 'must-revalidate';
-			// set noCaching to true in dev mode to get around stale data when you don't want it
-			var ttl = self.calcTtl(unit, value);
-			if (ttl === 0 || this.noCaching) {
-				return function(req, res, next) {
-					res.header(HEADER_KEY, NO_CACHE_KEY);
-					next();
-				};
-			}
+        self.client.get(key, function (err, cacheObject) {
+          if (err) {
+            self.emit("error", err);
+            return next();
+          }
+          // if the stale key expires, we let one request through to refresh the cache
+          // this helps us avoid dog piles and herds
+          self.client.get(staleKey, function (err, stale) {
+            if (err) {
+              self.emit("error", err);
+              return next();
+            }
 
+            res.header(HEADER_KEY, MAX_AGE_KEY + "=" + ttl + ", " + MUST_REVALIDATE_KEY);
 
-			return function(req, res, next) {
-				// only cache on get and head
-				if (req.method !== 'GET' && req.method !== 'HEAD') {
-					return next();
-				}
+            if (!stale) {
+              self.client.set(staleKey, STALE_REFRESH, GEN_TIME);
+              cacheObject = null;
+            }
 
-				var key = self.genCacheKey(req);
-				var staleKey = key + ".stale";
-				var realTtl = ttl + GEN_TIME * 2;
+            if (cacheObject) {
+              self.emit("hit", key);
+              return self.sendCached(res, cacheObject);
+            }
 
-				self.client.get(key, function(err, cacheObject) {
-					if (err) {
-						self.emit("error", err);
-						return next();
-					}
-					// if the stale key expires, we let one request through to refresh the cache
-					// this helps us avoid dog piles and herds
-					self.client.get(staleKey, function(err, stale) {
-						if (err) {
-							self.emit("error", err);
-							return next();
-						}
+            res._responseBody = "";
 
-						res.header(HEADER_KEY, MAX_AGE_KEY + "=" + ttl + ", " + MUST_REVALIDATE_KEY);
+            self.buildEnd(res, key, staleKey, realTtl, ttl);
+            self.buildWrite(res);
 
-						if (!stale) {
-							self.client.set(staleKey, STALE_REFRESH, GEN_TIME);
-							cacheObject = null;
-						}
-
-						if (cacheObject) {
-							self.emit("hit", key);
-							return self.sendCached(res, cacheObject);
-						}
-
-						res._responseBody = "";
-
-						self.buildEnd(res, key, staleKey, realTtl, ttl);
-						self.buildWrite(res);
-
-						res.header(self.cacheHeader, false);
-						next();
-						self.emit("miss", key);
-					});
-				});
-			};
-		};
-	}
+            res.header(self.cacheHeader, false);
+            next();
+            self.emit("miss", key);
+          });
+        });
+      };
+    };
+  }
 };


### PR DESCRIPTION
Keep `perpage` in the same format always, not sometimes `perPage`. `perPage` would be preferred, but this public API is already in wide usage.
Fix inconsistencies in utils functions.
Add JsDoc for important utils functions.
Also clean up some issues for JSCS compliance. Clean up inconsistent naming, formatting, and logic.
