### PR TITLE
fix(events): pull in a wider range of events to cover the full DevFest season

### DIFF
--- a/lib/tasks/fetch_events.js
+++ b/lib/tasks/fetch_events.js
@@ -14,33 +14,37 @@ require('superagent-retry')(request);
 
 module.exports = function (id, params, cb) {
   params = params || {};
-  var month = params.month > 0 ? params.month - 1 : moment().month() || moment().month();
+  var month = params.month > 0 ? params.month - 1 : moment().month();
   var year = params.year || moment().year();
 
-  var lastDayOfMonth = moment().year(year).month(month).add(1, 'months').date(10).seconds(0).minutes(0).hours(0).unix();
-  var firstDayOfMonth = moment().year(year).month(month).date(1).subtract(10, 'days')
-    .seconds(0).minutes(0).hours(0).unix();
+  console.log('[task ' + id + '] asked to fetch events starting with month="' + month + '" year="' + year + '".');
 
-  console.log("[task " + id + "] fetching events (start: " + firstDayOfMonth + ", end: " + lastDayOfMonth);
+  var firstDayOfMonth = moment().year(year).month(month).date(1).subtract(1, 'months')
+    .seconds(0).minutes(0).hours(0).unix();
+  var lastDayOfMonth = moment().year(year).month(month).add(3, 'months').seconds(0).minutes(0).hours(0).unix();
+
+  console.log('[task ' + id + '] fetching events: start: "' + moment.unix(firstDayOfMonth).format('MMM DD YYYY') +
+    '", end: "' + moment.unix(lastDayOfMonth).format('MMM DD YYYY') + '"...');
+
   async.series([
     function (callback) {
       Chapter.find({}).exec(function (err, chapters) {
         async.each(chapters, function (chapter, chapterCallback) {
           devsite.fetchEventsForChapter(firstDayOfMonth, lastDayOfMonth, chapter._id, function (err, events) {
             if (events) {
-              request.get("https://developers.google.com/events/feed/json?group=" + chapter._id + "&start=" +
-                          firstDayOfMonth + "&end=" + lastDayOfMonth)
+              request.get('https://developers.google.com/events/feed/json?group=' + chapter._id + '&start=' +
+                          firstDayOfMonth + '&end=' + lastDayOfMonth)
                 .retry(5).end(function (err, res) {
 
                   if (err || !res) {
-                    console.log("error fetching events");
+                    console.log('error fetching events');
                     chapterCallback(err);
                   } else {
                     if (events.length !== res.body.length) {
-                      console.log("chapter " + chapter.name);
-                      console.log("client says there are: " + events.length + " events");
-                      console.log("devsite has " + res.body.length + " events");
-                      console.log("EVENT COUNT MISMATCH!!!");
+                      console.log('chapter ' + chapter.name);
+                      console.log('client says there are: ' + events.length + ' events');
+                      console.log('devsite has ' + res.body.length || 0 + ' events');
+                      console.log('EVENT COUNT MISMATCH!!!');
                     }
 
                     async.each(events, function (event, eventsCallback) {
@@ -51,7 +55,7 @@ module.exports = function (id, params, cb) {
                         eventsCallback(err);
                       });
                     }, function (err) {
-                      console.log("[task " + id + "] saved " + events.length + " events");
+                      console.log('[task ' + id + '] saved ' + events.length + ' events');
                       chapterCallback(err);
                     });
                   }
@@ -61,13 +65,13 @@ module.exports = function (id, params, cb) {
             }
           });
         }, function (err) {
-          console.log("[task " + id + "] fetched_events");
-          callback(err, "done");
+          console.log('[task ' + id + '] fetched_events');
+          callback(err, 'done');
         });
       });
     },
     function (callback) {
-      console.log("[task " + id + "] fetching tags for events");
+      console.log('[task ' + id + '] fetching tags for events');
       var processTag = function (tag, tagCallback, err, events) {
         events = events || [];
         async.each(events, function (ev, evCallback) {
@@ -96,7 +100,7 @@ module.exports = function (id, params, cb) {
         var tags = [];
 
         for (var key in tagsObject) {
-          if (tagsObject[key].id !== "gdg")
+          if (tagsObject[key].id !== 'gdg')
             tags.push({
               id: tagsObject[key].id,
               title: key
@@ -117,13 +121,13 @@ module.exports = function (id, params, cb) {
             }
           });
         }, function (err) {
-          console.log("[task " + id + "] done fetching tags");
+          console.log('[task ' + id + '] done fetching tags');
           callback(err, 'two');
         });
       });
     }
   ], function (err) {
-    console.log("[task " + id + "] done");
+    console.log('[task ' + id + '] done');
     if (err) console.log(err);
     // All done
     cb(err);


### PR DESCRIPTION
Previously we only pulled in -10days to +1month from the 10th of this month.
We now pull in -1month from the 1st of this month to +3 months from today.
Improved log output for fetch_events task.
Replaced `"` with `'` for JSHint compliance.

Fixes #55.
