### PR TITLE
Fix navbar issue #75

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -316,6 +316,11 @@ li {
       overflow: visible;
     }
 
+    #navbar.navbar-inner.navbar_open {
+      display: inline-block;
+      width: 100vw;
+    }
+
     .organizer {
       margin-left: 6px;
       margin-right: 4px;


### PR DESCRIPTION
Some simple CSS that allows the mobile navbar to pushdown the content of the page so they do not overlap.
