### PR TITLE
fix(maps): update to Google Maps API 3.27

### DIFF
--- a/app/scripts/hub.config.js
+++ b/app/scripts/hub.config.js
@@ -10,7 +10,7 @@ angular.module('gdgxHubApp')
   .config(function ($routeProvider, $locationProvider, $httpProvider, uiGmapGoogleMapApiProvider, GOOGLE_API_KEY) {
     uiGmapGoogleMapApiProvider.configure({
       key: GOOGLE_API_KEY,
-      v: '3.24',
+      v: '3.27',
       libraries: 'weather,geometry,visualization'
     });
 


### PR DESCRIPTION
fixes 
```
Google Maps API warning: RetiredVersion https://developers.google.com/maps/documentation/javascript/error-messages#retired-version
```